### PR TITLE
Update pixels to 0.8.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ bevy_diagnostic = "0.5"
 bevy_ecs = "0.5"
 bevy_window = "0.5"
 bevy_winit = "0.5"
-pixels = "0.7"
+pixels = "0.8"
 
 [dev-dependencies]
 bevy_internal = { version = "0.5", features = ["bevy_winit"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,10 +10,16 @@ repository = "https://github.com/dtcristo/bevy_pixels"
 keywords = ["bevy", "pixels", "graphics", "2d", "framebuffer"]
 categories = ["game-engines", "graphics", "rendering"]
 exclude = ["images/**/*"]
+resolver = "2"
 
 [dependencies]
-bevy = { version = "0.5", default_features = false, features = ["bevy_winit"] }
-pixels = "0.3"
+bevy_app = "0.5"
+bevy_diagnostic = "0.5"
+bevy_ecs = "0.5"
+bevy_window = "0.5"
+bevy_winit = "0.5"
+pixels = "0.7"
 
 [dev-dependencies]
+bevy_internal = { version = "0.5", features = ["bevy_winit"] }
 rand = "0.8"

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -97,11 +97,11 @@ fn setup_system(mut commands: Commands) {
 fn bounce_system(mut query: Query<(&Position, &mut Velocity, &Size, &mut Color)>) {
     for (position, mut velocity, size, mut color) in query.iter_mut() {
         let mut bounce = false;
-        if position.x <= 0 || position.x + size.width > WIDTH {
+        if position.x == 0 || position.x + size.width > WIDTH {
             velocity.x *= -1;
             bounce = true;
         }
-        if position.y <= 0 || position.y + size.height > HEIGHT {
+        if position.y == 0 || position.y + size.height > HEIGHT {
             velocity.y *= -1;
             bounce = true;
         }

--- a/examples/minimal.rs
+++ b/examples/minimal.rs
@@ -1,5 +1,8 @@
-use bevy::{app::AppExit, prelude::*, window::WindowResizeConstraints};
+use bevy_app::{prelude::*, AppExit};
+use bevy_ecs::prelude::*;
+use bevy_internal::prelude::*;
 use bevy_pixels::prelude::*;
+use bevy_window::WindowResizeConstraints;
 use rand::prelude::*;
 
 const WIDTH: u32 = 320;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -82,13 +82,13 @@ impl PixelsPlugin {
     ) {
         diagnostics.add(Diagnostic::new(Self::RENDER_TIME, "render_time", 20).with_suffix("s"));
 
-        let primary_window_id = windows
+        let window_id = windows
             .get_primary()
             .expect("primary window not found")
             .id();
 
         let winit_window = winit_windows
-            .get_window(primary_window_id)
+            .get_window(window_id)
             .expect("failed to get primary winit window");
 
         let window_size = winit_window.inner_size();
@@ -97,10 +97,7 @@ impl PixelsPlugin {
         let pixels = Pixels::new(options.width, options.height, surface_texture)
             .expect("failed to create pixels");
 
-        commands.insert_resource(PixelsResource {
-            pixels: pixels,
-            window_id: primary_window_id,
-        });
+        commands.insert_resource(PixelsResource { pixels, window_id });
     }
 
     pub fn window_resize_system(
@@ -134,10 +131,7 @@ impl PixelsPlugin {
         }
     }
 
-    pub fn render_system(
-        mut resource: ResMut<PixelsResource>,
-        mut diagnostics: ResMut<Diagnostics>,
-    ) {
+    pub fn render_system(resource: Res<PixelsResource>, mut diagnostics: ResMut<Diagnostics>) {
         let start = Instant::now();
 
         resource.pixels.render().expect("failed to render pixels");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,15 +2,14 @@ pub mod prelude {
     pub use crate::{PixelsOptions, PixelsPlugin, PixelsResource, PixelsStage};
 }
 
-pub use bevy;
 pub use pixels;
 
-use bevy::{
-    diagnostic::{Diagnostic, DiagnosticId, Diagnostics},
-    prelude::*,
-    window::{WindowBackendScaleFactorChanged, WindowId, WindowResized},
-    winit::WinitWindows,
-};
+use bevy_app::prelude::*;
+use bevy_diagnostic::{Diagnostic, DiagnosticId, Diagnostics};
+use bevy_ecs::prelude::*;
+use bevy_window::prelude::*;
+use bevy_window::{WindowBackendScaleFactorChanged, WindowId, WindowResized};
+use bevy_winit::WinitWindows;
 use pixels::{Pixels, SurfaceTexture};
 use std::time::Instant;
 


### PR DESCRIPTION
Use separate crates instead of the `bevy` uber-crate. Workaround for Cargo package resolution error with `syn`.

This may not be as pretty, but it works.