### PR TITLE
feat: re-export feature flags from `bevy_winit`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ pixels = "0.8"
 [dev-dependencies]
 bevy_internal = { version = "0.5", features = ["bevy_winit"] }
 rand = "0.8"
+
+[features]
+default = ["x11"]
+x11 = ["bevy_winit/x11"]
+wayland = ["bevy_winit/wayland"]


### PR DESCRIPTION
Bevy re-exports display server options from winit on Linux, this does the same to allow Linux end-users to activate the correct themselves.