### PR TITLE
Update to bevy 0.11

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy_pixels"
 description = "Bevy plugin that uses Pixels (a tiny pixel buffer) for rendering"
-version = "0.10.0"
+version = "0.11.0"
 authors = ["David Cristofaro <david@dtcristo.com>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -22,8 +22,8 @@ wayland = ["bevy/wayland"]
 x11 = ["bevy/x11"]
 
 [dependencies]
-bevy = { version = "0.10", default_features = false, features = ["bevy_winit"] }
-pixels = "0.12"
+bevy = { version = "0.11", default_features = false, features = ["bevy_winit"] }
+pixels = "0.13"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 pollster = "0.3"

--- a/examples/bounce/Cargo.toml
+++ b/examples/bounce/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bevy = { version = "0.10", default_features = false }
+bevy = { version = "0.11", default_features = false }
 bevy_pixels = { path = "../../" }
 rand = "0.8"

--- a/examples/bounce/src/main.rs
+++ b/examples/bounce/src/main.rs
@@ -58,7 +58,7 @@ fn main() {
             }),
             ..default()
         }))
-        .add_plugin(PixelsPlugin {
+        .add_plugins(PixelsPlugin {
             primary_window: Some(PixelsOptions {
                 width: INITIAL_WIDTH,
                 height: INITIAL_HEIGHT,
@@ -66,12 +66,13 @@ fn main() {
                 ..default()
             }),
         })
-        .add_plugin(FrameTimeDiagnosticsPlugin::default())
-        .add_plugin(LogDiagnosticsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(bevy::window::close_on_esc)
-        .add_systems((bounce, movement).chain().in_set(PixelsSet::Update))
+        .add_plugins(FrameTimeDiagnosticsPlugin)
+        .add_plugins(LogDiagnosticsPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, bevy::window::close_on_esc)
+        .add_systems(Update, (bounce, movement).chain().in_set(PixelsSet::Update))
         .add_systems(
+            PostUpdate,
             (draw_background, draw_objects)
                 .chain()
                 .in_set(PixelsSet::Draw),

--- a/examples/custom_render/Cargo.toml
+++ b/examples/custom_render/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bevy = { version = "0.10", default_features = false }
+bevy = { version = "0.11", default_features = false }
 bevy_pixels = { path = "../../", default_features = false }

--- a/examples/custom_render/src/main.rs
+++ b/examples/custom_render/src/main.rs
@@ -4,12 +4,12 @@ use bevy_pixels::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(PixelsPlugin::default())
-        .add_system(bevy::window::close_on_esc)
-        .add_system(draw.in_set(PixelsSet::Draw))
+        .add_plugins(PixelsPlugin::default())
+        .add_systems(Update, bevy::window::close_on_esc)
+        .add_systems(PostUpdate, draw.in_set(PixelsSet::Draw))
         // Custom render system. Default `render` cargo feature must be disabled before
         // defining a custom render system. Use `default_features = "false"` in Cargo.toml.
-        .add_system(render.in_set(PixelsSet::Render))
+        .add_systems(Last, render.in_set(PixelsSet::Render))
         .run();
 }
 

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bevy = { version = "0.10", default_features = false }
+bevy = { version = "0.11", default_features = false }
 bevy_pixels = { path = "../../" }

--- a/examples/minimal/src/main.rs
+++ b/examples/minimal/src/main.rs
@@ -4,11 +4,11 @@ use bevy_pixels::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(PixelsPlugin::default())
-        .add_system(bevy::window::close_on_esc)
+        .add_plugins(PixelsPlugin::default())
+        .add_systems(Update, bevy::window::close_on_esc)
         // Add systems that draw to the buffer in `PixelsSet::Draw` set (or before)
         // to ensure they are rendered in the current frame.
-        .add_system(draw.in_set(PixelsSet::Draw))
+        .add_systems(PostUpdate, draw.in_set(PixelsSet::Draw))
         .run();
 }
 

--- a/examples/multiple_windows/Cargo.toml
+++ b/examples/multiple_windows/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2021"
 publish = false
 
 [dependencies]
-bevy = { version = "0.10", default_features = false }
+bevy = { version = "0.11", default_features = false }
 bevy_pixels = { path = "../../" }

--- a/examples/multiple_windows/src/main.rs
+++ b/examples/multiple_windows/src/main.rs
@@ -4,10 +4,10 @@ use bevy_pixels::prelude::*;
 fn main() {
     App::new()
         .add_plugins(DefaultPlugins)
-        .add_plugin(PixelsPlugin::default())
-        .add_startup_system(setup)
-        .add_system(bevy::window::close_on_esc)
-        .add_system(draw.in_set(PixelsSet::Draw))
+        .add_plugins(PixelsPlugin::default())
+        .add_systems(Startup, setup)
+        .add_systems(Update, bevy::window::close_on_esc)
+        .add_systems(PostUpdate, draw.in_set(PixelsSet::Draw))
         .run();
 }
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -20,25 +20,23 @@ impl Default for PixelsPlugin {
 
 impl Plugin for PixelsPlugin {
     fn build(&self, app: &mut App) {
-        app.configure_sets((
-            PixelsSet::Update.in_base_set(CoreSet::Update),
-            PixelsSet::Draw.in_base_set(CoreSet::PostUpdate),
-            PixelsSet::Render.in_base_set(CoreSet::Last),
-        ))
-        .add_startup_system(system::setup)
-        .add_system(system::create_pixels.in_base_set(CoreSet::First))
-        .add_systems(
-            (
-                system::window_change,
-                system::window_resize,
-                system::resize_buffer.after(system::window_resize),
-            )
-                .in_base_set(CoreSet::PreUpdate),
-        );
+        app.configure_set(Update, PixelsSet::Update)
+            .configure_set(PostUpdate, PixelsSet::Draw)
+            .configure_set(Last, PixelsSet::Render)
+            .add_systems(Startup, system::setup)
+            .add_systems(First, system::create_pixels)
+            .add_systems(
+                PreUpdate,
+                (
+                    system::window_change,
+                    system::window_resize,
+                    system::resize_buffer.after(system::window_resize),
+                ),
+            );
 
         #[cfg(feature = "render")]
         {
-            app.add_system(system::render.in_set(PixelsSet::Render));
+            app.add_systems(Last, system::render.in_set(PixelsSet::Render));
         }
 
         // If supplied, attach the primary window [`PixelsOptions`] component to the [`Window`]

--- a/src/system_set.rs
+++ b/src/system_set.rs
@@ -2,11 +2,11 @@ use bevy::prelude::*;
 
 #[derive(SystemSet, Debug, Hash, PartialEq, Eq, Clone)]
 pub enum PixelsSet {
-    /// Runs in [`CoreSet::Update`] base set. Use this set for simulation logic before draw.
+    /// Runs in [`Update`] schedule. Use this set for simulation logic before draw.
     Update,
-    /// Runs in [`CoreSet::PostUpdate`] base set. Use this set for logic that draws to the buffer.
+    /// Runs in [`PostUpdate`] schedule. Use this set for logic that draws to the buffer.
     Draw,
-    /// Runs in [`CoreSet::Last`] base set. This set is used internally for rendering the buffer to
+    /// Runs in [`Last`] schedule. This set is used internally for rendering the buffer to
     /// the surface.
     Render,
 }


### PR DESCRIPTION
I tried to support bevy 0.11 while reading the [migration document](https://bevyengine.org/learn/migration-guides/0.10-0.11/ ).
I couldn't decide if `PixelsSet` is still necessary, but I left it.

I confirmed that all examples work on Mac PC.
