### PR TITLE
Update Bevy to 0.19 and pixels to 0.17

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.17.0] - 2026-08-11
+
+### Changed
+
+- Updated `bevy` to 0.19.
+- Updated `pixels` to 0.17, including its update from `wgpu` 27 to 29.
+- Raised the minimum supported Rust version to 1.95.
+
+### Fixed
+
+- Initialize `pixels` asynchronously with a supported web texture format without blocking the
+  browser event loop.
+
 ## [0.16.0] - 2026-04-11
 
 ### Added
@@ -161,7 +174,8 @@
 
 Initial release.
 
-[Unreleased]: https://github.com/dtcristo/bevy_pixels/compare/v0.16.0...HEAD
+[Unreleased]: https://github.com/dtcristo/bevy_pixels/compare/v0.17.0...HEAD
+[0.17.0]: https://github.com/dtcristo/bevy_pixels/releases/tag/v0.17.0
 [0.16.0]: https://github.com/dtcristo/bevy_pixels/releases/tag/v0.16.0
 [0.15.0]: https://github.com/dtcristo/bevy_pixels/releases/tag/v0.15.0
 [0.14.0]: https://github.com/dtcristo/bevy_pixels/releases/tag/v0.14.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,9 +1,10 @@
 [package]
 name = "bevy_pixels"
 description = "Bevy plugin that uses Pixels (a tiny pixel buffer) for rendering"
-version = "0.16.0"
+version = "0.17.0"
 authors = ["David Cristofaro <david@dtcristo.com>"]
 edition = "2024"
+rust-version = "1.95"
 license = "MIT OR Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/dtcristo/bevy_pixels"
@@ -22,11 +23,10 @@ wayland = ["bevy/wayland"]
 x11 = ["bevy/x11"]
 
 [dependencies]
-bevy = { version = "0.18", default-features = false, features = ["bevy_winit"] }
-pixels = "0.16"
+bevy = { version = "0.19", default-features = false, features = ["bevy_winit"] }
+pixels = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
-pollster = "0.3"
 getrandom = { version = "0.3", features = ["wasm_js"] }
 
 [workspace]

--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Add `bevy` and `bevy_pixels` to `Cargo.toml`. Be sure to disable `bevy`'s `rende
 
 ```toml
 [dependencies]
-bevy = { version = "0.18", default-features = false }
-bevy_pixels = "0.16"
+bevy = { version = "0.19", default-features = false }
+bevy_pixels = "0.17"
 ```
 
 Add `PixelsPlugin` to your Bevy project.
@@ -71,6 +71,7 @@ fn draw(mut wrapper: Single<&mut PixelsWrapper>) {
 
 | bevy_pixels | bevy | pixels |
 | ----------- | ---- | ------ |
+| 0.17        | 0.19 | 0.17   |
 | 0.16        | 0.18 | 0.16   |
 | 0.15        | 0.15 | 0.15   |
 | 0.14        | 0.14 | 0.15   |

--- a/examples/bounce/Cargo.toml
+++ b/examples/bounce/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = { version = "0.19", default-features = false }
 bevy_pixels = { path = "../../" }
 rand = "0.9"

--- a/examples/custom_render/Cargo.toml
+++ b/examples/custom_render/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = { version = "0.19", default-features = false }
 bevy_pixels = { path = "../../", default-features = false }

--- a/examples/mandelbrot/Cargo.toml
+++ b/examples/mandelbrot/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = { version = "0.19", default-features = false }
 bevy_pixels = { path = "../../" }

--- a/examples/minimal/Cargo.toml
+++ b/examples/minimal/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = { version = "0.19", default-features = false }
 bevy_pixels = { path = "../../" }

--- a/examples/multiple_windows/Cargo.toml
+++ b/examples/multiple_windows/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2024"
 publish = false
 
 [dependencies]
-bevy = { version = "0.18", default-features = false }
+bevy = { version = "0.19", default-features = false }
 bevy_pixels = { path = "../../" }

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -3,7 +3,7 @@ use crate::{diagnostic, prelude::*, system};
 use bevy::{
     app::MainScheduleOrder,
     diagnostic::{Diagnostic, RegisterDiagnostic},
-    ecs::{schedule::ExecutorKind, system::SystemState, world::World},
+    ecs::{schedule::SingleThreadedExecutor, system::SystemState, world::World},
     prelude::*,
     window::{PrimaryWindow, WindowBackendScaleFactorChanged, WindowResized},
 };
@@ -19,7 +19,9 @@ pub struct PixelsPlugin {
 fn insert_primary_window_options(world: &mut World, options: PixelsOptions) {
     let mut system_state: SystemState<Query<Entity, With<PrimaryWindow>>> = SystemState::new(world);
     let primary_window = {
-        let query = system_state.get(world);
+        let query = system_state
+            .get(world)
+            .expect("primary window query should be valid");
         query.single().ok()
     };
 
@@ -39,10 +41,10 @@ impl Default for PixelsPlugin {
 impl Plugin for PixelsPlugin {
     fn build(&self, app: &mut App) {
         let mut draw_schedule = Schedule::new(Draw);
-        draw_schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+        draw_schedule.set_executor(SingleThreadedExecutor::new());
 
         let mut render_schedule = Schedule::new(Render);
-        render_schedule.set_executor_kind(ExecutorKind::SingleThreaded);
+        render_schedule.set_executor(SingleThreadedExecutor::new());
         #[cfg(feature = "render")]
         render_schedule.add_systems(system::render);
 
@@ -60,6 +62,12 @@ impl Plugin for PixelsPlugin {
                     system::resize_buffer.after(system::window_resize),
                 ),
             );
+
+        #[cfg(target_arch = "wasm32")]
+        app.add_systems(
+            First,
+            system::finish_pixels_initialization.after(system::create_pixels),
+        );
 
         // Ensure `Draw` and `Render` schedules execute at the correct moment.
         let mut order = app.world_mut().resource_mut::<MainScheduleOrder>();
@@ -114,21 +122,6 @@ mod tests {
         assert!(
             app.world()
                 .contains_resource::<Messages<WindowBackendScaleFactorChanged>>()
-        );
-    }
-
-    #[test]
-    fn plugin_uses_single_threaded_custom_schedules() {
-        let mut app = App::new();
-        app.add_plugins(PixelsPlugin::default());
-
-        assert_eq!(
-            app.get_schedule(Draw).unwrap().get_executor_kind(),
-            ExecutorKind::SingleThreaded
-        );
-        assert_eq!(
-            app.get_schedule(Render).unwrap().get_executor_kind(),
-            ExecutorKind::SingleThreaded
         );
     }
 

--- a/src/system.rs
+++ b/src/system.rs
@@ -6,17 +6,21 @@ use crate::prelude::*;
 #[cfg(feature = "render")]
 #[cfg(not(target_arch = "wasm32"))]
 use bevy::diagnostic::Diagnostics;
+#[cfg(target_arch = "wasm32")]
+use bevy::tasks::{AsyncComputeTaskPool, Task, futures::check_ready};
 use bevy::{
     ecs::system::NonSendMarker,
     prelude::*,
     window::{PresentMode, RawHandleWrapper, WindowBackendScaleFactorChanged, WindowResized},
 };
 use pixels::{PixelsBuilder, SurfaceTexture};
-#[cfg(target_arch = "wasm32")]
-use pollster::FutureExt as _;
 #[cfg(feature = "render")]
 #[cfg(not(target_arch = "wasm32"))]
 use std::time::Instant;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Component)]
+pub(crate) struct PendingPixels(Task<Result<PixelsWrapper, pixels::Error>>);
 
 fn pixels_present_mode(present_mode: PresentMode) -> pixels::wgpu::PresentMode {
     match present_mode {
@@ -38,6 +42,7 @@ fn buffer_size_for_window(window: &Window, scale_factor: f32) -> (u32, u32) {
 
 /// Create [`PixelsWrapper`] (and underlying [`Pixels`] buffer) for all suitable [`Window`] with
 /// a [`PixelsOptions`] component.
+#[cfg(not(target_arch = "wasm32"))]
 #[allow(clippy::type_complexity)]
 pub fn create_pixels(
     mut commands: Commands,
@@ -55,23 +60,64 @@ pub fn create_pixels(
             thread_locked_handle,
         );
 
-        let pixels = {
-            let builder = PixelsBuilder::new(options.width, options.height, surface_texture)
-                .present_mode(pixels_present_mode(window.present_mode));
-
-            #[cfg(not(target_arch = "wasm32"))]
-            {
-                builder.build()
-            }
-            #[cfg(target_arch = "wasm32")]
-            {
-                // TODO: Find a way to asynchronously load pixels on web.
-                builder.build_async().block_on()
-            }
-        }
-        .expect("failed to create pixels");
+        let pixels = PixelsBuilder::new(options.width, options.height, surface_texture)
+            .present_mode(pixels_present_mode(window.present_mode))
+            .build()
+            .expect("failed to create pixels");
 
         commands.entity(entity).insert(PixelsWrapper { pixels });
+    }
+}
+
+/// Begin creating [`PixelsWrapper`] asynchronously for suitable web windows.
+#[cfg(target_arch = "wasm32")]
+#[allow(clippy::type_complexity)]
+pub fn create_pixels(
+    mut commands: Commands,
+    query: Query<
+        (Entity, &PixelsOptions, &Window, &RawHandleWrapper),
+        (Without<PixelsWrapper>, Without<PendingPixels>),
+    >,
+    _main_thread: NonSendMarker,
+) {
+    for (entity, options, window, raw_handle_wrapper) in &query {
+        // SAFETY: `NonSendMarker` forces this system onto Bevy's main thread. The spawned local
+        // task remains on the browser thread required by the thread-affine window handle.
+        let thread_locked_handle = unsafe { raw_handle_wrapper.get_handle() };
+        let surface_texture = SurfaceTexture::new(
+            window.physical_width(),
+            window.physical_height(),
+            thread_locked_handle,
+        );
+        let builder = PixelsBuilder::new(options.width, options.height, surface_texture)
+            .present_mode(pixels_present_mode(window.present_mode))
+            .texture_format(pixels::wgpu::TextureFormat::Rgba8Unorm)
+            .surface_texture_format(pixels::wgpu::TextureFormat::Rgba8Unorm);
+        let task = AsyncComputeTaskPool::get().spawn_local(async move {
+            builder
+                .build_async()
+                .await
+                .map(|pixels| PixelsWrapper { pixels })
+        });
+
+        commands.entity(entity).insert(PendingPixels(task));
+    }
+}
+
+/// Finish creating [`PixelsWrapper`] for web windows whose asynchronous initialization completed.
+#[cfg(target_arch = "wasm32")]
+pub fn finish_pixels_initialization(
+    mut commands: Commands,
+    mut query: Query<(Entity, &mut PendingPixels)>,
+) {
+    for (entity, mut pending) in &mut query {
+        if let Some(result) = check_ready(&mut pending.0) {
+            let wrapper = result.expect("failed to create pixels");
+            commands
+                .entity(entity)
+                .remove::<PendingPixels>()
+                .insert(wrapper);
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- release `bevy_pixels` 0.17.0 with Bevy 0.19 and pixels 0.17
- declare Rust 1.95 as the minimum supported version
- migrate to Bevy's `SingleThreadedExecutor` and fallible `SystemState` API
- initialize pixels asynchronously on WASM with the web-supported `Rgba8Unorm` texture format
- update examples, README compatibility mapping, and changelog

## Why

Bevy 0.19 removes the `ExecutorKind` API and makes `SystemState` validation fallible. pixels 0.17 moves to wgpu 29. Browser validation also showed that blocking `build_async` with pollster stalls the WASM event loop, while pixels' default sRGB surface format is unsupported by the web canvas backend.

## Impact

The existing `bevy_pixels` public API remains unchanged. Downstream custom rendering code sees pixels' wgpu 27 to 29 update through the existing pixels re-export and public `PixelsWrapper` field.

## Validation

- `cargo fmt --all --check`
- `cargo check --workspace --all-targets --all-features`
- `cargo test --workspace --all-features`
- `cargo clippy --workspace --all-targets --all-features`
- `cargo clippy --package bevy_pixels --target wasm32-unknown-unknown --all-features`
- `cargo package --allow-dirty`
- native smoke: `minimal`, `custom_render`, `multiple_windows`
- browser smoke: minimal WASM example rendered with one canvas and zero console errors

Clippy completes with pre-existing style warnings in system tests/window-change code; no new migration error.

## Post-merge release checklist

- [x] tag the merged commit as `v0.17.0`
- [x] create GitHub release `v0.17.0` from the changelog entry
- [x] publish `bevy_pixels` 0.17.0 to crates.io
- [x] verify crates.io and docs.rs metadata
