### PR TITLE
Deepen window pixel synchronization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- Centralized window-to-pixel size synchronization for consistent behavior across multiple
+  windows.
+
+### Fixed
+
+- Resize the pixel buffer when `PixelsOptions` dimensions change, even when
+  `auto_resize_buffer` is disabled. This option now controls only window-driven buffer sizing.
+- Log buffer and surface resize failures instead of silently discarding them.
+
 ## [0.17.0] - 2026-08-11
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ wayland = ["bevy/wayland"]
 x11 = ["bevy/x11"]
 
 [dependencies]
-bevy = { version = "0.19", default-features = false, features = ["bevy_winit"] }
+bevy = { version = "0.19", default-features = false, features = ["bevy_log", "bevy_winit"] }
 pixels = "0.17"
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod schedule;
 
 mod options;
 mod plugin;
+mod synchronization;
 mod system;
 mod wrapper;
 

--- a/src/plugin.rs
+++ b/src/plugin.rs
@@ -1,4 +1,4 @@
-use crate::{diagnostic, prelude::*, system};
+use crate::{diagnostic, prelude::*, synchronization, system};
 
 use bevy::{
     app::MainScheduleOrder,
@@ -54,14 +54,7 @@ impl Plugin for PixelsPlugin {
             .add_schedule(draw_schedule)
             .add_schedule(render_schedule)
             .add_systems(First, system::create_pixels)
-            .add_systems(
-                PreUpdate,
-                (
-                    system::window_change,
-                    system::window_resize,
-                    system::resize_buffer.after(system::window_resize),
-                ),
-            );
+            .add_systems(PreUpdate, synchronization::synchronize);
 
         #[cfg(target_arch = "wasm32")]
         app.add_systems(

--- a/src/synchronization.rs
+++ b/src/synchronization.rs
@@ -1,0 +1,74 @@
+use crate::prelude::*;
+
+use bevy::{
+    log::warn,
+    prelude::*,
+    window::{WindowBackendScaleFactorChanged, WindowResized},
+};
+use std::collections::HashSet;
+
+#[derive(Default)]
+struct DesiredSizes {
+    buffer: Option<(u32, u32)>,
+    surface: Option<(u32, u32)>,
+}
+
+/// Synchronize caller-selected and window-derived sizes with each window's pixel buffer.
+pub fn synchronize(
+    mut window_resized: MessageReader<WindowResized>,
+    mut scale_factor_changed: MessageReader<WindowBackendScaleFactorChanged>,
+    mut windows: Query<(
+        Entity,
+        &mut PixelsOptions,
+        &Window,
+        Option<&mut PixelsWrapper>,
+    )>,
+) {
+    let resized: HashSet<Entity> = window_resized.read().map(|event| event.window).collect();
+    let surface_changed: HashSet<Entity> = scale_factor_changed
+        .read()
+        .map(|event| event.window)
+        .chain(resized.iter().copied())
+        .collect();
+
+    for (entity, mut options, window, wrapper) in &mut windows {
+        let mut desired = DesiredSizes::default();
+        let wrapper_added = wrapper.as_ref().is_some_and(|wrapper| wrapper.is_added());
+
+        if resized.contains(&entity) && options.auto_resize_buffer {
+            let (width, height) = buffer_size_for_window(window, options.scale_factor);
+            options.width = width;
+            options.height = height;
+            desired.buffer = Some((width, height));
+        } else if options.is_changed() || wrapper_added {
+            desired.buffer = Some((options.width, options.height));
+        }
+
+        if (surface_changed.contains(&entity) || wrapper_added) && options.auto_resize_surface {
+            desired.surface = Some((window.physical_width(), window.physical_height()));
+        }
+
+        let Some(mut wrapper) = wrapper else {
+            continue;
+        };
+
+        if let Some((width, height)) = desired.surface
+            && let Err(error) = wrapper.pixels.resize_surface(width, height)
+        {
+            warn!(?entity, %error, "failed to synchronize pixel surface size");
+        }
+
+        if let Some((width, height)) = desired.buffer
+            && let Err(error) = wrapper.pixels.resize_buffer(width, height)
+        {
+            warn!(?entity, %error, "failed to synchronize pixel buffer size");
+        }
+    }
+}
+
+fn buffer_size_for_window(window: &Window, scale_factor: f32) -> (u32, u32) {
+    (
+        (window.width() / scale_factor).floor() as u32,
+        (window.height() / scale_factor).floor() as u32,
+    )
+}

--- a/src/system.rs
+++ b/src/system.rs
@@ -11,7 +11,7 @@ use bevy::tasks::{AsyncComputeTaskPool, Task, futures::check_ready};
 use bevy::{
     ecs::system::NonSendMarker,
     prelude::*,
-    window::{PresentMode, RawHandleWrapper, WindowBackendScaleFactorChanged, WindowResized},
+    window::{PresentMode, RawHandleWrapper},
 };
 use pixels::{PixelsBuilder, SurfaceTexture};
 #[cfg(feature = "render")]
@@ -31,13 +31,6 @@ fn pixels_present_mode(present_mode: PresentMode) -> pixels::wgpu::PresentMode {
         PresentMode::AutoVsync => pixels::wgpu::PresentMode::AutoVsync,
         PresentMode::AutoNoVsync => pixels::wgpu::PresentMode::AutoNoVsync,
     }
-}
-
-fn buffer_size_for_window(window: &Window, scale_factor: f32) -> (u32, u32) {
-    (
-        (window.width() / scale_factor).floor() as u32,
-        (window.height() / scale_factor).floor() as u32,
-    )
 }
 
 /// Create [`PixelsWrapper`] (and underlying [`Pixels`] buffer) for all suitable [`Window`] with
@@ -121,56 +114,6 @@ pub fn finish_pixels_initialization(
     }
 }
 
-/// Resize buffer and surface to window when it is resized.
-pub fn window_resize(
-    mut window_resized_events: MessageReader<WindowResized>,
-    mut query: Query<(&mut PixelsWrapper, &mut PixelsOptions, &Window)>,
-) {
-    for event in window_resized_events.read() {
-        if let Ok((mut wrapper, mut options, window)) = query.get_mut(event.window) {
-            if options.auto_resize_buffer {
-                (options.width, options.height) =
-                    buffer_size_for_window(window, options.scale_factor);
-            }
-
-            if options.auto_resize_surface {
-                resize_surface_to_window(&mut wrapper, window);
-            }
-        }
-    }
-}
-
-/// Resize surface to window when scale factor changes.
-pub fn window_change(
-    mut window_backend_scale_factor_changed_events: MessageReader<WindowBackendScaleFactorChanged>,
-    mut query: Query<(&mut PixelsWrapper, &PixelsOptions, &Window)>,
-) {
-    for event in window_backend_scale_factor_changed_events.read() {
-        if let Ok((mut wrapper, options, window)) = query.get_mut(event.window) {
-            if options.auto_resize_surface {
-                resize_surface_to_window(&mut wrapper, window);
-            }
-        }
-    }
-}
-
-fn resize_surface_to_window(wrapper: &mut PixelsWrapper, window: &Window) {
-    let _ = wrapper
-        .pixels
-        .resize_surface(window.physical_width(), window.physical_height());
-}
-
-/// Resize buffer when width and height change.
-pub fn resize_buffer(
-    mut query: Query<(&mut PixelsWrapper, &PixelsOptions), Changed<PixelsOptions>>,
-) {
-    for (mut wrapper, options) in &mut query {
-        if options.auto_resize_buffer {
-            let _ = wrapper.pixels.resize_buffer(options.width, options.height);
-        }
-    }
-}
-
 /// Render buffer to surface.
 #[cfg(feature = "render")]
 pub fn render(
@@ -196,7 +139,6 @@ pub fn render(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bevy::window::WindowResolution;
 
     #[test]
     fn present_mode_mapping_matches_pixels() {
@@ -224,29 +166,5 @@ mod tests {
             pixels_present_mode(PresentMode::AutoNoVsync),
             pixels::wgpu::PresentMode::AutoNoVsync
         );
-    }
-
-    #[test]
-    fn buffer_size_uses_window_logical_dimensions() {
-        let mut window = Window::default();
-        window.resolution = WindowResolution::new(640, 480).with_scale_factor_override(1.0);
-
-        assert_eq!(buffer_size_for_window(&window, 2.0), (320, 240));
-    }
-
-    #[test]
-    fn buffer_size_rounds_down_fractional_results() {
-        let mut window = Window::default();
-        window.resolution = WindowResolution::new(641, 479).with_scale_factor_override(1.0);
-
-        assert_eq!(buffer_size_for_window(&window, 2.0), (320, 239));
-    }
-
-    #[test]
-    fn buffer_size_respects_window_scale_factor_override() {
-        let mut window = Window::default();
-        window.resolution = WindowResolution::new(1280, 720).with_scale_factor_override(2.0);
-
-        assert_eq!(buffer_size_for_window(&window, 2.0), (320, 180));
     }
 }

--- a/tests/public_api.rs
+++ b/tests/public_api.rs
@@ -189,3 +189,99 @@ fn plugin_registers_window_messages_for_public_apps() {
             .contains_resource::<Messages<WindowBackendScaleFactorChanged>>()
     );
 }
+
+#[test]
+fn window_resize_updates_each_automatic_buffer_size_without_a_pixels_wrapper() {
+    let mut app = App::new();
+    app.add_plugins(PixelsPlugin {
+        primary_window: None,
+    });
+
+    let automatic = app
+        .world_mut()
+        .spawn((
+            Window {
+                resolution: bevy::window::WindowResolution::new(640, 480),
+                ..default()
+            },
+            PixelsOptions {
+                scale_factor: 2.0,
+                ..default()
+            },
+        ))
+        .id();
+    let manual = app
+        .world_mut()
+        .spawn((
+            Window {
+                resolution: bevy::window::WindowResolution::new(900, 600),
+                ..default()
+            },
+            PixelsOptions {
+                width: 160,
+                height: 90,
+                scale_factor: 3.0,
+                auto_resize_buffer: false,
+                ..default()
+            },
+        ))
+        .id();
+    let fractional = app
+        .world_mut()
+        .spawn((
+            Window {
+                resolution: bevy::window::WindowResolution::new(641, 479),
+                ..default()
+            },
+            PixelsOptions {
+                scale_factor: 2.0,
+                ..default()
+            },
+        ))
+        .id();
+    let high_dpi = app
+        .world_mut()
+        .spawn((
+            Window {
+                resolution: bevy::window::WindowResolution::new(1280, 720)
+                    .with_scale_factor_override(2.0),
+                ..default()
+            },
+            PixelsOptions {
+                scale_factor: 2.0,
+                ..default()
+            },
+        ))
+        .id();
+
+    app.world_mut().write_message(WindowResized {
+        window: automatic,
+        width: 640.0,
+        height: 480.0,
+    });
+    app.world_mut().write_message(WindowResized {
+        window: manual,
+        width: 900.0,
+        height: 600.0,
+    });
+    app.world_mut().write_message(WindowResized {
+        window: fractional,
+        width: 641.0,
+        height: 479.0,
+    });
+    app.world_mut().write_message(WindowResized {
+        window: high_dpi,
+        width: 640.0,
+        height: 360.0,
+    });
+    app.update();
+
+    let automatic = app.world().get::<PixelsOptions>(automatic).unwrap();
+    assert_eq!((automatic.width, automatic.height), (320, 240));
+    let manual = app.world().get::<PixelsOptions>(manual).unwrap();
+    assert_eq!((manual.width, manual.height), (160, 90));
+    let fractional = app.world().get::<PixelsOptions>(fractional).unwrap();
+    assert_eq!((fractional.width, fractional.height), (320, 239));
+    let high_dpi = app.world().get::<PixelsOptions>(high_dpi).unwrap();
+    assert_eq!((high_dpi.width, high_dpi.height), (320, 180));
+}


### PR DESCRIPTION
## Summary

- centralize window-to-pixel sizing in one internal synchronization module
- resize buffers for manual `PixelsOptions` dimension changes even when automatic window sizing is disabled
- reconcile newly initialized native/web buffers and surfaces with current window state
- warn on buffer and surface resize failures
- add an Unreleased changelog section

## Why

Resize behavior was spread across three systems, two window messages, mutable options, and plugin ordering. The documented behavior also conflicted with the implementation: `auto_resize_buffer` blocked manual dimension changes although it is documented as controlling window-driven automatic sizing.

The new module owns buffer intent, surface intent, message interpretation, ordering, late initialization, and failure policy. `auto_resize_buffer` now gates only window-derived dimensions.

Relates to #26, candidate 1.

## Impact

- callers can manually change buffer dimensions with automatic sizing disabled
- multiple windows use the same synchronization policy
- web buffers that finish initialization late reconcile against current options and surface dimensions
- resize failures are visible through Bevy logging

## Validation

- `cargo fmt --check`
- `cargo clippy --lib --all-features -- -D warnings`
- `cargo test --workspace --all-targets --all-features`
- `cargo check --target wasm32-unknown-unknown --workspace --all-targets --all-features`
- public App/World tracer verified red then green for automatic/manual policy, fractional sizing, HiDPI, and multiple windows
- two-axis review: Standards passed; Spec found no incorrect behavior or scope creep

## Test limitation

Direct buffer/surface resize and warning assertions require constructing `PixelsWrapper`, which requires a real wgpu window surface. `pixels` has no supported headless constructor. This PR keeps the concrete call path instead of adding a hypothetical fake adapter solely for tests.
